### PR TITLE
Default variable to false

### DIFF
--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -14,7 +14,7 @@ ami_os               = "centos6"
 #
 # specific settings
 #
-accept_mlsa          = "true"
+accept_mlsa          = "false"
 allowed_cidrs        = "10.0.0.0/8,192.168.0.0/16,172.16.0.0/12"
 client_version       = "12.8.1"
 domain               = ""


### PR DESCRIPTION
Defaulting `accept_mlsa` to `false`. Change to `true` to explicitly accept the Chef MLSA
